### PR TITLE
feat: Set the portal name based on the settings

### DIFF
--- a/lib/Provider.tsx
+++ b/lib/Provider.tsx
@@ -50,6 +50,10 @@ export const ConfigProvider: React.FC<ConfigProviderProps> = ({ children, api, t
           responses.map((r) => r.json()),
         );
 
+        if(rest.portalName) {
+          document.title = rest.portalName;
+        }
+
         const fontUrls = theme?.typography?.urls;
 
         // load fonts


### PR DESCRIPTION
Added new code for the fe-base project that will set the page title to the portal name. This makes more sense than showing the default "API Suite" title. 